### PR TITLE
Comment stripping script added to report

### DIFF
--- a/doc/src/Anon.sh
+++ b/doc/src/Anon.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This script has ABSOLUTELY NO ERROR CHECKING
+# But it shouldn't overwrite anything in typical case
+
+student=0
+srcdir="$1"
+dstdir="$2"
+
+mkdir -p "$dstdir"
+
+find "$srcdir/students" "$srcdir/groups" -mindepth 1 -maxdepth 1 -type d -not -path "$srcdir/students" -not -path "$srcdir/groups" -print0 | while read -d $'\0' dir
+do
+  studentName=`basename "$dir"`
+  echo "Anonymizing student $studentName"
+  curDstDir="$dstdir/student_$student"
+  # Make output directory
+  mkdir -p "$curDstDir"
+  # Increment student number
+  student=$((student+1))
+  
+  curDir=`pwd`
+
+  # Unzip anything we find. Ignore errors that might occur because there are no zip files.
+  find "$dir" -type f -name '*.zip' -print0 | while read -d $'\0' zip
+  do
+    dirName=`dirname "$zip"`
+    echo "Unzipping $zip to $dirName"
+    unzip -o -d "$dirName" "$zip"
+  done
+
+  # Untar any tars
+  find "$dir" -type f -name '*.tar' -print0 | while read -d $'\0' tar
+  do
+    dirName=`dirname "$tar"`
+    cd "$dirName"
+    echo "Untarring $tar to $dirName"
+    tar -xf "$tar"
+  done
+
+  cd "$curDir"
+
+  # Loop through all .c and .h files in that directory and anonymize them
+  find "$dir" \( \( -type f -name '*.c' \) -or \( -type f -name '*.h' \) -or \( -type f -name '*.cpp' \) -or \( -type f -name '*.hpp' \) \)  -print0 | while read -d $'\0' file
+  do
+    # Run strip_comments script from GNU folks. Pipe output into output file.
+    fileBasename=`basename "$file"`
+    echo "Stripping comments from $file, outputting to $fileBasename"
+    ./strip_comments.sed "$file" > "$curDstDir/$fileBasename"
+  done
+done
+
+echo "Done!"

--- a/doc/src/includes.ltx
+++ b/doc/src/includes.ltx
@@ -15,4 +15,4 @@
 \usepackage{float} % For absolute figure location specification
 \usepackage[framemethod=tikz]{mdframed} % For highlighting paragraphs
 \usepackage[locale=US]{siunitx}
-
+\usepackage{listings}

--- a/doc/src/methodology.ltx
+++ b/doc/src/methodology.ltx
@@ -84,16 +84,16 @@ information was removed, with the caveat that a professor manually review
 anonymized code to ensure that no obvious identifying information remained.
 Professor Lauer graciously offered to perform this final vetting.
 
-\begin{verbatim}
-# TODO; the anonymization script, in full, will go here
-\end{verbatim}
+\lstset{caption={Anonymization Script Source},frame=single,breaklines=true,numbers=left,label={lst:anonscript}}
+\lstinputlisting[language=bash]{Anon.sh}
 
 A script was constructed in Bash to accomplish this goal in a largely-automated
-fashion to make it feasible to obtain large bodies of test code. Given the
-nature of the script, its use is limited to submissions written in languages
-that use comments delineated with the ``\texttt{//}'' and ``\texttt{/* */}''
-symbols. The anonymization script contains a verbatim copy of the
-\textit{remcomms} Sed script for removing C comments, by Brian Hiles
+fashion to make it feasible to obtain large bodies of test code. This script is
+shown in Listing~\ref{lst:anonscript}. Given the nature of the script, its use
+is limited to submissions written in languages that use comments delineated with
+the ``\texttt{//}'' and ``\texttt{/* */}'' symbols. The anonymization script
+uses a verbatim copy of the \textit{remcomms} Sed script by Brian Hiles for
+removing C comments
 \footnote{available at http://sed.sourceforge.net/grabbag/scripts/remccoms3.sed}.
 
 Using this script, a large volume of test code was obtained from several past

--- a/doc/src/remove_comments.sed
+++ b/doc/src/remove_comments.sed
@@ -1,0 +1,95 @@
+#! /bin/sed -nf
+
+# Remove C and C++ comments, by Brian Hiles (brian_hiles@rocketmail.com)
+
+# Sped up (and bugfixed to some extent) by Paolo Bonzini (bonzini@gnu.org)
+# Works its way through the line, copying to hold space the text up to the
+# first special character (/, ", ').  The original version went exactly a
+# character at a time, hence the greater speed of this one.  But the concept
+# and especially the trick of building the line in hold space are entirely
+# merit of Brian.
+
+:loop
+
+# This line is sufficient to remove C++ comments!
+/^\/\// s,.*,,
+
+/^$/{
+  x
+  p
+  n
+  b loop
+}
+/^"/{
+  :double
+  /^$/{
+    x
+    p
+    n
+    /^"/b break
+    b double
+  }
+
+  H
+  x
+  s,\n\(.[^\"]*\).*,\1,
+  x
+  s,.[^\"]*,,
+  
+  /^"/b break
+  /^\\/{
+    H
+    x
+    s,\n\(.\).*,\1,
+    x
+    s/.//
+  }
+  b double
+}
+
+/^'/{
+  :single
+  /^$/{
+    x
+    p
+    n
+    /^'/b break
+    b single
+  }
+  H
+  x
+  s,\n\(.[^\']*\).*,\1,
+  x
+  s,.[^\']*,,
+  
+  /^'/b break
+  /^\\/{
+    H
+    x
+    s,\n\(.\).*,\1,
+    x
+    s/.//
+  }
+  b single
+}
+
+/^\/\*/{
+  s/.//
+  :ccom
+  s,^.[^*]*,,
+  /^$/ n
+  /^\*\//{
+    s/..//
+    b loop
+  }
+  b ccom
+}
+
+:break
+H
+x
+s,\n\(.[^"'/]*\).*,\1,
+x
+s/.[^"'/]*//
+b loop
+

--- a/src/main/java/edu/wpi/checksims/ChecksimException.java
+++ b/src/main/java/edu/wpi/checksims/ChecksimException.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims;

--- a/src/main/java/edu/wpi/checksims/ChecksimRunner.java
+++ b/src/main/java/edu/wpi/checksims/ChecksimRunner.java
@@ -24,7 +24,6 @@ package edu.wpi.checksims;
 import com.google.common.collect.ImmutableList;
 import edu.wpi.checksims.algorithm.AlgorithmRegistry;
 import edu.wpi.checksims.algorithm.CommonCodeRemover;
-import edu.wpi.checksims.algorithm.SimilarityDetector;
 import edu.wpi.checksims.algorithm.output.OutputRegistry;
 import edu.wpi.checksims.algorithm.output.SimilarityMatrix;
 import edu.wpi.checksims.algorithm.output.SimilarityMatrixPrinter;
@@ -311,7 +310,7 @@ public class ChecksimRunner {
         // If we are performing common code detection...
         if(config.doRemoveCommonCode()) {
             // Perform common code removal before preprocessor application
-            submissions = ImmutableList.copyOf(CommonCodeRemover.removeCommonCodeFromSubmissionsInList(submissions, config.getCommonCode(), config.getCommonCodeRemovalAlgorithm()));
+            submissions = ImmutableList.copyOf(CommonCodeRemover.removeCommonCodeFromSubmissions(submissions, config.getCommonCode(), config.getCommonCodeRemovalAlgorithm()));
         }
 
         // Apply all preprocessors

--- a/src/main/java/edu/wpi/checksims/SmithWaterman/SmithWaterman.java
+++ b/src/main/java/edu/wpi/checksims/SmithWaterman/SmithWaterman.java
@@ -1,3 +1,24 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
+ */
+
 package edu.wpi.checksims.SmithWaterman;
 
 import java.io.BufferedReader;

--- a/src/main/java/edu/wpi/checksims/SmithWaterman/SmithWatermanParameters.java
+++ b/src/main/java/edu/wpi/checksims/SmithWaterman/SmithWatermanParameters.java
@@ -1,3 +1,24 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
+ */
+
 package edu.wpi.checksims.SmithWaterman;
 
 /**

--- a/src/main/java/edu/wpi/checksims/SmithWaterman/SmithWatermanResults.java
+++ b/src/main/java/edu/wpi/checksims/SmithWaterman/SmithWatermanResults.java
@@ -1,3 +1,24 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
+ */
+
 package edu.wpi.checksims.SmithWaterman;
 
 /**

--- a/src/main/java/edu/wpi/checksims/algorithm/AlgorithmRegistry.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/AlgorithmRegistry.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm;

--- a/src/main/java/edu/wpi/checksims/algorithm/AlgorithmResults.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/AlgorithmResults.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm;

--- a/src/main/java/edu/wpi/checksims/algorithm/AlgorithmResults.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/AlgorithmResults.java
@@ -64,6 +64,6 @@ public final class AlgorithmResults {
 
     @Override
     public String toString() {
-        return "Plagiarism comparison of submissions named " + a.getName() + " and " + b.getName();
+        return "Similarity results for submissions named " + a.getName() + " and " + b.getName();
     }
 }

--- a/src/main/java/edu/wpi/checksims/algorithm/AlgorithmRunner.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/AlgorithmRunner.java
@@ -46,7 +46,7 @@ public final class AlgorithmRunner {
         Set<UnorderedPair<Submission>> allPairs = UnorderedPair.generatePairsFromList(submissions);
 
         // Perform parallel analysis of all submission pairs to generate a results list
-        Collection<AlgorithmResults> results = ParallelAlgorithm.applyAlgorithm(algorithm, allPairs);
+        Collection<AlgorithmResults> results = ParallelAlgorithm.parallelSimilarityDetection(algorithm, allPairs);
 
         long endTime = System.currentTimeMillis();
         long timeElapsed = endTime - startTime;

--- a/src/main/java/edu/wpi/checksims/algorithm/CommonCodeRemover.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/CommonCodeRemover.java
@@ -21,23 +21,12 @@
 
 package edu.wpi.checksims.algorithm;
 
-import edu.wpi.checksims.ChecksimException;
-import edu.wpi.checksims.submission.ConcreteSubmission;
 import edu.wpi.checksims.submission.Submission;
-import edu.wpi.checksims.submission.ValidityIgnoringSubmission;
-import edu.wpi.checksims.token.TokenList;
-import edu.wpi.checksims.token.TokenType;
-import edu.wpi.checksims.token.tokenizer.FileTokenizer;
-import edu.wpi.checksims.util.UnorderedPair;
 import edu.wpi.checksims.util.threading.ParallelAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.DecimalFormat;
 import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 /**
  * Remove common code from submissions
@@ -56,6 +45,8 @@ public final class CommonCodeRemover {
      * @return Submissions from removeFrom rebuilt without common code
      */
     public static Collection<Submission> removeCommonCodeFromSubmissions(Collection<Submission> removeFrom, Submission common, SimilarityDetector algorithm) {
+        logs.info("Performing common code removal on " + removeFrom.size() + " submissions");
+
         return ParallelAlgorithm.parallelCommonCodeRemoval(algorithm, common, removeFrom);
     }
 }

--- a/src/main/java/edu/wpi/checksims/algorithm/SimilarityDetector.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/SimilarityDetector.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm;

--- a/src/main/java/edu/wpi/checksims/algorithm/commonsubstring/LongestCommonSubstring.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/commonsubstring/LongestCommonSubstring.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.commonsubstring;

--- a/src/main/java/edu/wpi/checksims/algorithm/linesimilarity/LineSimilarityChecker.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/linesimilarity/LineSimilarityChecker.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.linesimilarity;

--- a/src/main/java/edu/wpi/checksims/algorithm/linesimilarity/LineSimilarityChecker.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/linesimilarity/LineSimilarityChecker.java
@@ -99,6 +99,10 @@ public class LineSimilarityChecker implements SimilarityDetector {
         if(!a.getTokenType().equals(b.getTokenType())) {
             throw new ChecksimException("Token list type mismatch: submission " + a.getName() + " has type " +
                     linesA.type.toString() + ", while submission " + b.getName() + " has type " + linesB.type.toString());
+        } else if(a.equals(b)) {
+            finalA.stream().forEach((token) -> token.setValid(false));
+            finalB.stream().forEach((token) -> token.setValid(false));
+            return new AlgorithmResults(a, b, a.getNumTokens(), b.getNumTokens(), finalA, finalB);
         }
 
         MessageDigest hasher;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/OutputRegistry.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/OutputRegistry.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrix.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrix.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixAsCSVPrinter.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixAsCSVPrinter.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixAsHTMLPrinter.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixAsHTMLPrinter.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixAsMatrixPrinter.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixAsMatrixPrinter.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixPrinter.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixPrinter.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixThresholdPrinter.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/output/SimilarityMatrixThresholdPrinter.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.output;

--- a/src/main/java/edu/wpi/checksims/algorithm/preprocessor/LowercasePreprocessor.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/preprocessor/LowercasePreprocessor.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.preprocessor;

--- a/src/main/java/edu/wpi/checksims/algorithm/preprocessor/PreprocessorRegistry.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/preprocessor/PreprocessorRegistry.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.preprocessor;

--- a/src/main/java/edu/wpi/checksims/algorithm/preprocessor/SubmissionPreprocessor.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/preprocessor/SubmissionPreprocessor.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.preprocessor;

--- a/src/main/java/edu/wpi/checksims/algorithm/smithwaterman/SmithWaterman.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/smithwaterman/SmithWaterman.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.smithwaterman;

--- a/src/main/java/edu/wpi/checksims/algorithm/smithwaterman/SmithWatermanParameters.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/smithwaterman/SmithWatermanParameters.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.smithwaterman;

--- a/src/main/java/edu/wpi/checksims/algorithm/smithwaterman/SmithWatermanResults.java
+++ b/src/main/java/edu/wpi/checksims/algorithm/smithwaterman/SmithWatermanResults.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.algorithm.smithwaterman;

--- a/src/main/java/edu/wpi/checksims/submission/AbstractSubmissionDecorator.java
+++ b/src/main/java/edu/wpi/checksims/submission/AbstractSubmissionDecorator.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.submission;

--- a/src/main/java/edu/wpi/checksims/submission/ConcreteSubmission.java
+++ b/src/main/java/edu/wpi/checksims/submission/ConcreteSubmission.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.submission;

--- a/src/main/java/edu/wpi/checksims/submission/Submission.java
+++ b/src/main/java/edu/wpi/checksims/submission/Submission.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.submission;

--- a/src/main/java/edu/wpi/checksims/submission/ValidityEnsuringSubmission.java
+++ b/src/main/java/edu/wpi/checksims/submission/ValidityEnsuringSubmission.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.submission;

--- a/src/main/java/edu/wpi/checksims/submission/ValidityIgnoringSubmission.java
+++ b/src/main/java/edu/wpi/checksims/submission/ValidityIgnoringSubmission.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.submission;

--- a/src/main/java/edu/wpi/checksims/token/AbstractTokenDecorator.java
+++ b/src/main/java/edu/wpi/checksims/token/AbstractTokenDecorator.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/ConcreteToken.java
+++ b/src/main/java/edu/wpi/checksims/token/ConcreteToken.java
@@ -21,19 +21,10 @@
 
 package edu.wpi.checksims.token;
 
-import com.google.common.collect.BiMap;
-import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Maps;
-
-import java.util.concurrent.atomic.AtomicInteger;
-
 /**
  * Interface for comparable tokens of various types
  */
 public final class ConcreteToken implements Token {
-    private static final BiMap<Object, Integer> lexemeMap = Maps.synchronizedBiMap(HashBiMap.create());
-    private static final AtomicInteger lexemeIndex = new AtomicInteger();
-
     private boolean isValid;
     private final int lexeme;
     private final TokenType type;
@@ -45,13 +36,7 @@ public final class ConcreteToken implements Token {
     public ConcreteToken(Object token, TokenType type, boolean isValid) {
         this.isValid = isValid;
         this.type = type;
-
-        if(lexemeMap.containsKey(token)) {
-            this.lexeme = lexemeMap.get(token);
-        } else {
-            this.lexeme = lexemeIndex.getAndIncrement();
-            lexemeMap.put(token, lexeme);
-        }
+        this.lexeme = LexemeMap.getLexemeForToken(token);
     }
 
     private ConcreteToken(int lexeme, TokenType type, boolean isValid) {
@@ -72,11 +57,7 @@ public final class ConcreteToken implements Token {
 
     @Override
     public Object getToken() {
-        if(!lexemeMap.inverse().containsKey(lexeme)) {
-            throw new RuntimeException("No mapping for lexeme " + lexeme);
-        }
-
-        return lexemeMap.inverse().get(lexeme);
+        return LexemeMap.getTokenForLexeme(lexeme);
     }
 
     @Override

--- a/src/main/java/edu/wpi/checksims/token/ConcreteToken.java
+++ b/src/main/java/edu/wpi/checksims/token/ConcreteToken.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/ImmutableToken.java
+++ b/src/main/java/edu/wpi/checksims/token/ImmutableToken.java
@@ -21,8 +21,6 @@
 
 package edu.wpi.checksims.token;
 
-import org.apache.commons.lang.NotImplementedException;
-
 /**
  * An immutable view of a token
  */

--- a/src/main/java/edu/wpi/checksims/token/ImmutableToken.java
+++ b/src/main/java/edu/wpi/checksims/token/ImmutableToken.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/LexemeMap.java
+++ b/src/main/java/edu/wpi/checksims/token/LexemeMap.java
@@ -1,0 +1,84 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
+ */
+
+package edu.wpi.checksims.token;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Maps lexemes (integers) to the original token contents
+ */
+public final class LexemeMap {
+    private LexemeMap() {}
+
+    // TODO: does this need to be synchronized if we're synchronizing the getLexemeForToken method?
+    private static final BiMap<Object, Integer> lexemeMap = Maps.synchronizedBiMap(HashBiMap.create());
+    private static final AtomicInteger lexemeIndex = new AtomicInteger();
+
+    /**
+     * @param token Token to get lexeme for
+     * @return Lexeme representing this token. If no such lexeme existed prior, it is created and mapped to the token.
+     */
+    public static synchronized int getLexemeForToken(Object token) {
+        if(!lexemeMap.containsKey(token)) {
+            int newLexeme = lexemeIndex.getAndIncrement();
+
+            Integer previous = lexemeMap.put(token, newLexeme);
+
+            if(previous != null) {
+                throw new RuntimeException("Overwrote lexeme mapping for token " + token.toString());
+            }
+
+            return newLexeme;
+        } else {
+            return lexemeMap.get(token);
+        }
+    }
+
+    /**
+     * Throws RuntimeException if lexeme does not map to any key.
+     *
+     * @todo Investigate conversion to checked exception?
+     * @param lexeme Lexeme being requested
+     * @return Token of given type
+     */
+    public static Object getTokenForLexeme(int lexeme) {
+        if(!lexemeMap.inverse().containsKey(lexeme)) {
+            throw new RuntimeException("Lexeme " + lexeme + " does not map to any value!");
+        }
+
+        return lexemeMap.inverse().get(lexeme);
+    }
+
+    /**
+     * Used to reset state for unit tests
+     *
+     * CAUTION! This will obliterate the existing token mappings! DO NOT CALL IN PRODUCTION CODE!
+     */
+    static void resetMappings() {
+        lexemeMap.clear();
+        lexemeIndex.set(0);
+    }
+}

--- a/src/main/java/edu/wpi/checksims/token/Token.java
+++ b/src/main/java/edu/wpi/checksims/token/Token.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/TokenList.java
+++ b/src/main/java/edu/wpi/checksims/token/TokenList.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/TokenType.java
+++ b/src/main/java/edu/wpi/checksims/token/TokenType.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/ValidityEnsuringToken.java
+++ b/src/main/java/edu/wpi/checksims/token/ValidityEnsuringToken.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/ValidityIgnoringToken.java
+++ b/src/main/java/edu/wpi/checksims/token/ValidityIgnoringToken.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token;

--- a/src/main/java/edu/wpi/checksims/token/tokenizer/FileCharTokenizer.java
+++ b/src/main/java/edu/wpi/checksims/token/tokenizer/FileCharTokenizer.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tokenizer;

--- a/src/main/java/edu/wpi/checksims/token/tokenizer/FileLineTokenizer.java
+++ b/src/main/java/edu/wpi/checksims/token/tokenizer/FileLineTokenizer.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tokenizer;

--- a/src/main/java/edu/wpi/checksims/token/tokenizer/FileTokenizer.java
+++ b/src/main/java/edu/wpi/checksims/token/tokenizer/FileTokenizer.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tokenizer;

--- a/src/main/java/edu/wpi/checksims/token/tokenizer/FileWhitespaceTokenizer.java
+++ b/src/main/java/edu/wpi/checksims/token/tokenizer/FileWhitespaceTokenizer.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tokenizer;

--- a/src/main/java/edu/wpi/checksims/token/tree/SubmissionID.java
+++ b/src/main/java/edu/wpi/checksims/token/tree/SubmissionID.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tree;

--- a/src/main/java/edu/wpi/checksims/token/tree/SuffixTreeNode.java
+++ b/src/main/java/edu/wpi/checksims/token/tree/SuffixTreeNode.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tree;

--- a/src/main/java/edu/wpi/checksims/token/tree/SuffixTreeRoot.java
+++ b/src/main/java/edu/wpi/checksims/token/tree/SuffixTreeRoot.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tree;

--- a/src/main/java/edu/wpi/checksims/token/tree/SuffixTreeShared.java
+++ b/src/main/java/edu/wpi/checksims/token/tree/SuffixTreeShared.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.token.tree;

--- a/src/main/java/edu/wpi/checksims/util/Direction.java
+++ b/src/main/java/edu/wpi/checksims/util/Direction.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util;

--- a/src/main/java/edu/wpi/checksims/util/TwoDimArrayCoord.java
+++ b/src/main/java/edu/wpi/checksims/util/TwoDimArrayCoord.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util;

--- a/src/main/java/edu/wpi/checksims/util/TwoDimIntArray.java
+++ b/src/main/java/edu/wpi/checksims/util/TwoDimIntArray.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util;

--- a/src/main/java/edu/wpi/checksims/util/UnorderedPair.java
+++ b/src/main/java/edu/wpi/checksims/util/UnorderedPair.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util;

--- a/src/main/java/edu/wpi/checksims/util/file/FileLineReader.java
+++ b/src/main/java/edu/wpi/checksims/util/file/FileLineReader.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util.file;

--- a/src/main/java/edu/wpi/checksims/util/file/FileStringWriter.java
+++ b/src/main/java/edu/wpi/checksims/util/file/FileStringWriter.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util.file;

--- a/src/main/java/edu/wpi/checksims/util/reflection/ReflectiveInstantiator.java
+++ b/src/main/java/edu/wpi/checksims/util/reflection/ReflectiveInstantiator.java
@@ -16,7 +16,7 @@
  *
  * CDDL HEADER END
  *
- * Copyright (c) 2014 Matthew Heon and Dolan Murvihill
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
  */
 
 package edu.wpi.checksims.util.reflection;

--- a/src/main/java/edu/wpi/checksims/util/threading/CommonCodeRemovalWorker.java
+++ b/src/main/java/edu/wpi/checksims/util/threading/CommonCodeRemovalWorker.java
@@ -1,0 +1,112 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * See LICENSE.txt included in this distribution for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at LICENSE.txt.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ *
+ * Copyright (c) 2014-2015 Matthew Heon and Dolan Murvihill
+ */
+
+package edu.wpi.checksims.util.threading;
+
+import edu.wpi.checksims.algorithm.AlgorithmResults;
+import edu.wpi.checksims.algorithm.SimilarityDetector;
+import edu.wpi.checksims.submission.ConcreteSubmission;
+import edu.wpi.checksims.submission.Submission;
+import edu.wpi.checksims.submission.ValidityIgnoringSubmission;
+import edu.wpi.checksims.token.TokenList;
+import edu.wpi.checksims.token.TokenType;
+import edu.wpi.checksims.token.tokenizer.FileTokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.DecimalFormat;
+import java.util.concurrent.Callable;
+
+/**
+ * Basic unit of thread execution for Common Code Removal
+ */
+public class CommonCodeRemovalWorker implements Callable<Submission> {
+    private final SimilarityDetector algorithm;
+    private final Submission common;
+    private final Submission removeFrom;
+
+    private static Logger logs = LoggerFactory.getLogger(CommonCodeRemovalWorker.class);
+
+    public CommonCodeRemovalWorker(SimilarityDetector algorithm, Submission common, Submission removeFrom) {
+        this.algorithm = algorithm;
+        this.common = common;
+        this.removeFrom = removeFrom;
+    }
+
+    /**
+     * Perform common code removal on given submission
+     *
+     * @return Submission with common code removed
+     * @throws Exception Unused - all exceptions will be RuntimeException or similar
+     */
+    @Override
+    public Submission call() throws Exception {
+        logs.debug("Performing common code removal on submission " + removeFrom.getName());
+
+        TokenType type = algorithm.getDefaultTokenType();
+        FileTokenizer tokenizer = FileTokenizer.getTokenizer(type);
+
+        // Re-tokenize input and common code using given token type
+        TokenList redoneIn = tokenizer.splitFile(removeFrom.getContentAsString());
+        TokenList redoneCommon = tokenizer.splitFile(common.getContentAsString());
+        
+        // Create new submissions with retokenized input
+        Submission computeIn = new ConcreteSubmission(removeFrom.getName(), removeFrom.getContentAsString(), redoneIn);
+        Submission computeCommon = new ConcreteSubmission(common.getName(), common.getContentAsString(), redoneCommon);
+
+        // Use the new submissions to compute this
+        AlgorithmResults results = algorithm.detectSimilarity(computeIn, computeCommon);
+
+        // The results contains two TokenLists, representing the final state of the submissions after similarity detection
+        // All common code should be marked invalid for the input submission's final list
+        TokenList listWithCommonInvalid;
+        float percentMatched;
+        int identTokens;
+        if(new ValidityIgnoringSubmission(results.a).equals(removeFrom)) {
+            listWithCommonInvalid = results.finalListA;
+            percentMatched = results.percentMatchedA();
+            identTokens = results.identicalTokensA;
+        } else {
+            listWithCommonInvalid = results.finalListB;
+            percentMatched = results.percentMatchedB();
+            identTokens = results.identicalTokensB;
+        }
+
+        // Recreate the string body of the submission from this new list
+        String newBody = listWithCommonInvalid.join(true);
+
+        // Retokenize the new body with the original tokenization
+        TokenType oldType = removeFrom.getTokenType();
+        FileTokenizer oldTokenizer = FileTokenizer.getTokenizer(oldType);
+        TokenList finalListGoodTokenization = oldTokenizer.splitFile(newBody);
+
+        DecimalFormat d = new DecimalFormat("###.00");
+        logs.trace("Submission " + removeFrom.getName() + " contained " + d.format(100 * percentMatched) + "% common code");
+        logs.trace("Removed " + identTokens + " common tokens (of " + removeFrom.getNumTokens() + " total)");
+
+        return new ConcreteSubmission(removeFrom.getName(), newBody, finalListGoodTokenization);
+    }
+
+    @Override
+    public String toString() {
+        return "Common Code Removal Worker for submission \"" + removeFrom.getName() + "\"";
+    }
+}

--- a/src/main/java/edu/wpi/checksims/util/threading/ParallelAlgorithm.java
+++ b/src/main/java/edu/wpi/checksims/util/threading/ParallelAlgorithm.java
@@ -50,13 +50,48 @@ public final class ParallelAlgorithm {
         threadCount = threads;
     }
 
-    public static Collection<AlgorithmResults> applyAlgorithm(SimilarityDetector algorithm, Collection<UnorderedPair<Submission>> pairs) {
+    /**
+     * Remove common code in parallel
+     *
+     * @param algorithm Algorithm to use for common code removal
+     * @param common Common code to remove
+     * @param submissions Submissions to remove from
+     * @return Submissions with common code removed
+     */
+    public static Collection<Submission> parallelCommonCodeRemoval(SimilarityDetector algorithm, Submission common, Collection<Submission> submissions) {
+        Collection<CommonCodeRemovalWorker> workers = submissions.stream().map((submission) -> new CommonCodeRemovalWorker(algorithm, common, submission)).collect(Collectors.toList());
+
+        return executeTasks(workers);
+    }
+
+    /**
+     * Detect similarities in parallel
+     *
+     * @param algorithm Algorithm to use for similarity detection
+     * @param pairs Pairs of submissions to perform detection on
+     * @return Collection of results, one for each pair
+     */
+    public static Collection<AlgorithmResults> parallelSimilarityDetection(SimilarityDetector algorithm, Collection<UnorderedPair<Submission>> pairs) {
+        // Map the pairs to ChecksimsWorker instances
+        Collection<SimilarityDetectionWorker> workers = pairs.stream().map((pair) -> new SimilarityDetectionWorker(algorithm, pair)).collect(Collectors.toList());
+
+        return executeTasks(workers);
+    }
+
+    /**
+     * Internal backend: Execute given tasks on a new thread pool
+     *
+     * Expects Callable tasks, with non-void returns. If the need for void returning functions emerges, might need
+     * another version of this?
+     *
+     * @param tasks Tasks to execute
+     * @param <T> Type returned by the tasks
+     * @return Collection of Ts
+     */
+    private static <T, T2 extends Callable<T>> Collection<T> executeTasks(Collection<T2> tasks) {
         ThreadPoolExecutor executor = new ThreadPoolExecutor(threadCount, threadCount, 1, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), new ThreadPoolExecutor.AbortPolicy());
 
-        logs.info("Starting similarity detection using " + threadCount + " threads.");
-
-        // Map the pairs to ChecksimsWorker instances
-        Collection<ChecksimsWorker> workers = pairs.stream().map((pair) -> new ChecksimsWorker(algorithm, pair)).collect(Collectors.toList());
+        logs.info("Starting work using " + threadCount + " threads.");
 
         // Invoke the executor on all the ChecksimsWorker instances
         try {
@@ -65,7 +100,7 @@ public final class ParallelAlgorithm {
             Thread monitorThread = new Thread(monitor);
             monitorThread.start();
 
-            List<Future<AlgorithmResults>> results = executor.invokeAll(workers);
+            List<Future<T>> results = executor.invokeAll(tasks);
 
             executor.shutdown();
 
@@ -123,7 +158,7 @@ class MonitorThread implements Runnable {
             // Only print if we have an update
             if(newComplete != currentComplete) {
                 currentComplete = newComplete;
-                logs.info("Processed " + currentComplete + "/" + total + " pairs");
+                logs.info("Processed " + currentComplete + "/" + total + " tasks");
             }
 
             try {
@@ -133,5 +168,10 @@ class MonitorThread implements Runnable {
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return "Monitoring thread for a ThreadPoolExecutor";
     }
 }

--- a/src/main/java/edu/wpi/checksims/util/threading/SimilarityDetectionWorker.java
+++ b/src/main/java/edu/wpi/checksims/util/threading/SimilarityDetectionWorker.java
@@ -32,13 +32,15 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.Callable;
 
 /**
- * Basic unit of thread execution. Takes two Submissions, applies an algorithm to them, returns results.
+ * Basic unit of thread execution for similarity detection.
+ *
+ * Takes two Submissions, applies an algorithm to them, returns results.
  */
-public class ChecksimsWorker implements Callable<AlgorithmResults> {
+public class SimilarityDetectionWorker implements Callable<AlgorithmResults> {
     private final SimilarityDetector algorithm;
     private final UnorderedPair<Submission> submissions;
 
-    private static Logger logs = LoggerFactory.getLogger(ChecksimsWorker.class);
+    private static Logger logs = LoggerFactory.getLogger(SimilarityDetectionWorker.class);
 
     /**
      * Construct a Callable to perform pairwise similarity detection for one pair of assignments
@@ -46,7 +48,7 @@ public class ChecksimsWorker implements Callable<AlgorithmResults> {
      * @param algorithm Algorithm to use
      * @param submissions Assignments to compare
      */
-    public ChecksimsWorker(SimilarityDetector algorithm, UnorderedPair<Submission> submissions) {
+    public SimilarityDetectionWorker(SimilarityDetector algorithm, UnorderedPair<Submission> submissions) {
         this.algorithm = algorithm;
         this.submissions = submissions;
     }
@@ -69,5 +71,10 @@ public class ChecksimsWorker implements Callable<AlgorithmResults> {
             logs.error("Fatal error running " + algorithm.getName() + " on submissions " + submissions.first.getName() + " and " + submissions.second.getName());
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public String toString() {
+        return "Similarity detection worker for submissions \"" + submissions.first.getName() + "\" and \"" + submissions.second.getName() + "\"";
     }
 }

--- a/src/test/java/edu/wpi/checksims/algorithm/CommonCodeRemoverTest.java
+++ b/src/test/java/edu/wpi/checksims/algorithm/CommonCodeRemoverTest.java
@@ -1,0 +1,94 @@
+package edu.wpi.checksims.algorithm;
+
+import com.google.common.collect.Iterables;
+import edu.wpi.checksims.algorithm.linesimilarity.LineSimilarityChecker;
+import edu.wpi.checksims.submission.ConcreteSubmission;
+import edu.wpi.checksims.submission.Submission;
+import edu.wpi.checksims.token.TokenList;
+import edu.wpi.checksims.token.TokenType;
+import edu.wpi.checksims.token.tokenizer.FileTokenizer;
+import edu.wpi.checksims.util.threading.CommonCodeRemovalWorker;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for common code removal
+ */
+public class CommonCodeRemoverTest {
+    private static Submission empty;
+    private static Submission abc;
+    private static Submission abcde;
+    private static SimilarityDetector lineCompare;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        FileTokenizer tokenizer = FileTokenizer.getTokenizer(TokenType.CHARACTER);
+
+        empty = new ConcreteSubmission("Empty", "", new TokenList(TokenType.CHARACTER));
+        abc = new ConcreteSubmission("ABC", "A\nB\nC\n", tokenizer.splitFile("A\nB\nC\n"));
+        abcde = new ConcreteSubmission("ABCDE", "A\nB\nC\nD\nE\n", tokenizer.splitFile("A\nB\nC\nD\nE\n"));
+
+        lineCompare = LineSimilarityChecker.getInstance();
+    }
+
+    @Test
+    public void TestCommonCodeRemovalJustWorker() throws Exception {
+        CommonCodeRemovalWorker worker = new CommonCodeRemovalWorker(lineCompare, empty, abc);
+
+        Submission result = worker.call();
+
+        assertNotNull(result);
+        assertEquals(result.getTokenType(), abc.getTokenType());
+        assertEquals(result.getName(), abc.getName());
+        assertEquals(result.getContentAsString(), abc.getContentAsString());
+        assertEquals(result.getContentAsTokens(), abc.getContentAsTokens());
+        assertEquals(result, abc);
+    }
+
+    @Test
+    public void TestRemoveCommonCodePreservesTokenType() {
+        Collection<Submission> removeFrom = Arrays.asList(abc);
+
+        Collection<Submission> results = CommonCodeRemover.removeCommonCodeFromSubmissions(removeFrom, empty, lineCompare);
+
+        Submission fromResults = Iterables.get(results, 0);
+
+        assertNotNull(results);
+        assertEquals(results.size(), 1);
+        assertEquals(fromResults.getTokenType(), abc.getTokenType());
+        assertEquals(fromResults.getName(), abc.getName());
+        assertEquals(fromResults.getContentAsString(), abc.getContentAsString());
+        assertEquals(fromResults.getContentAsTokens(), abc.getContentAsTokens());
+        assertEquals(fromResults, abc);
+    }
+
+    @Test
+    public void TestRemoveEmptyCommonCode() {
+        Collection<Submission> removeFrom = Arrays.asList(abc, abcde);
+
+        Collection<Submission> results = CommonCodeRemover.removeCommonCodeFromSubmissions(removeFrom, empty, lineCompare);
+
+        assertNotNull(results);
+        System.out.println(results.toString());
+        assertEquals(results.size(), 2);
+        assertTrue(results.contains(abc));
+        assertTrue(results.contains(abcde));
+    }
+
+    @Test
+    public void TestRemoveCommonCodeFromEmpty() {
+        Collection<Submission> removeFrom = Arrays.asList(empty);
+
+        Collection<Submission> results = CommonCodeRemover.removeCommonCodeFromSubmissions(removeFrom, abc, lineCompare);
+
+        assertNotNull(results);
+        assertEquals(results.size(), 1);
+        assertTrue(results.contains(empty));
+    }
+}

--- a/src/test/java/edu/wpi/checksims/algorithm/linesimilarity/LineSimilarityCheckerTest.java
+++ b/src/test/java/edu/wpi/checksims/algorithm/linesimilarity/LineSimilarityCheckerTest.java
@@ -1,0 +1,201 @@
+package edu.wpi.checksims.algorithm.linesimilarity;
+
+import edu.wpi.checksims.ChecksimException;
+import edu.wpi.checksims.algorithm.AlgorithmResults;
+import edu.wpi.checksims.algorithm.SimilarityDetector;
+import edu.wpi.checksims.submission.ConcreteSubmission;
+import edu.wpi.checksims.submission.Submission;
+import edu.wpi.checksims.token.TokenList;
+import edu.wpi.checksims.token.TokenType;
+import edu.wpi.checksims.token.tokenizer.FileTokenizer;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the Line Comparison algorithm
+ */
+public class LineSimilarityCheckerTest {
+    private static Submission empty;
+    private static Submission abc;
+    private static Submission aabc;
+    private static Submission abcde;
+    private static Submission def;
+    private static SimilarityDetector lineCompare;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        FileTokenizer tokenizer = FileTokenizer.getTokenizer(TokenType.LINE);
+
+        empty = new ConcreteSubmission("Empty", "", new TokenList(TokenType.LINE));
+        abc = new ConcreteSubmission("ABC", "A\nB\nC\n", tokenizer.splitFile("A\nB\nC\n"));
+        aabc = new ConcreteSubmission("AABC", "A\nA\nB\nC\n", tokenizer.splitFile("A\nA\nB\nC\n"));
+        abcde = new ConcreteSubmission("ABCDE", "A\nB\nC\nD\nE\n", tokenizer.splitFile("A\nB\nC\nD\nE\n"));
+        def = new ConcreteSubmission("DEF", "D\nE\nF\n", tokenizer.splitFile("D\nE\nF\n"));
+
+        lineCompare = LineSimilarityChecker.getInstance();
+    }
+
+    @Test(expected = ChecksimException.class)
+    public void TestErrorOnTokenTypeMismatch() throws ChecksimException {
+        lineCompare.detectSimilarity(empty, new ConcreteSubmission("Error", "", new TokenList(TokenType.CHARACTER)));
+    }
+
+    @Test
+    public void TestEmptySubmissionIsZeroPercentSimilar() throws ChecksimException {
+        AlgorithmResults results = lineCompare.detectSimilarity(empty, empty);
+
+        assertNotNull(results);
+        assertEquals(0, results.identicalTokensA);
+        assertEquals(0, results.identicalTokensB);
+        assertEquals(0, results.finalListA.size());
+        assertEquals(0, results.finalListB.size());
+    }
+
+    @Test
+    public void TestEmptySubmissionAndNonemptySubmission() throws ChecksimException {
+        AlgorithmResults results = lineCompare.detectSimilarity(empty, abc);
+
+        assertNotNull(results);
+        assertEquals(0, results.identicalTokensA);
+        assertEquals(0, results.identicalTokensB);
+
+        if(abc.equals(results.a)) {
+            assertEquals(results.finalListA.size(), abc.getNumTokens());
+            assertEquals(results.finalListA, abc.getContentAsTokens());
+        } else {
+            assertTrue(abc.equals(results.b));
+            assertEquals(results.finalListB.size(), abc.getNumTokens());
+            assertEquals(results.finalListB, abc.getContentAsTokens());
+        }
+    }
+
+    @Test
+    public void TestIdenticalSubmissions() throws Exception {
+        AlgorithmResults results = lineCompare.detectSimilarity(abc, abc);
+
+        TokenList expected = TokenList.cloneTokenList(abc.getContentAsTokens());
+        expected.stream().forEach((token) -> token.setValid(false));
+
+        assertNotNull(results);
+        assertEquals(results.identicalTokensB, results.identicalTokensA);
+        assertEquals(results.identicalTokensA, abc.getNumTokens());
+        assertEquals(results.finalListA, results.finalListB);
+        assertEquals(results.finalListA, expected);
+    }
+
+    @Test
+    public void TestSubmissionStrictSubset() throws ChecksimException {
+        AlgorithmResults results = lineCompare.detectSimilarity(abc, abcde);
+
+        TokenList expectedAbc = TokenList.cloneTokenList(abc.getContentAsTokens());
+        expectedAbc.stream().forEach((token) -> token.setValid(false));
+        TokenList expectedAbcde = TokenList.cloneTokenList(abcde.getContentAsTokens());
+        expectedAbcde.get(0).setValid(false);
+        expectedAbcde.get(1).setValid(false);
+        expectedAbcde.get(2).setValid(false);
+
+        assertNotNull(results);
+        assertEquals(results.identicalTokensA, results.identicalTokensB);
+        assertEquals(results.identicalTokensA, abc.getNumTokens());
+
+        if(abc.equals(results.a)) {
+            assertEquals(abcde, results.b);
+
+            assertEquals(results.finalListA, expectedAbc);
+            assertEquals(results.finalListB, expectedAbcde);
+        } else {
+            assertEquals(abc, results.b);
+            assertEquals(abcde, results.a);
+
+            assertEquals(results.finalListA, expectedAbcde);
+            assertEquals(results.finalListB, expectedAbc);
+        }
+    }
+
+    @Test
+    public void TestSubmissionsNoOverlap() throws ChecksimException {
+        AlgorithmResults results = lineCompare.detectSimilarity(abc, def);
+
+        assertNotNull(results);
+        assertEquals(results.identicalTokensA, results.identicalTokensB);
+        assertEquals(results.identicalTokensA, 0);
+
+        if(abc.equals(results.a)) {
+            assertEquals(def, results.b);
+
+            assertEquals(results.finalListB, def.getContentAsTokens());
+            assertEquals(results.finalListA, abc.getContentAsTokens());
+        } else {
+            assertEquals(abc, results.b);
+            assertEquals(def, results.a);
+
+            assertEquals(results.finalListA, def.getContentAsTokens());
+            assertEquals(results.finalListB, abc.getContentAsTokens());
+        }
+    }
+
+    @Test
+    public void TestSubmissionsSomeOverlap() throws ChecksimException {
+        AlgorithmResults results = lineCompare.detectSimilarity(abcde, def);
+
+        TokenList expectedAbcde = TokenList.cloneTokenList(abcde.getContentAsTokens());
+        expectedAbcde.get(3).setValid(false);
+        expectedAbcde.get(4).setValid(false);
+
+        TokenList expectedDef = TokenList.cloneTokenList(def.getContentAsTokens());
+        expectedDef.get(0).setValid(false);
+        expectedDef.get(1).setValid(false);
+
+        assertNotNull(results);
+        assertEquals(results.identicalTokensA, results.identicalTokensB);
+        assertEquals(results.identicalTokensA, 2);
+
+        if(abcde.equals(results.a)) {
+            assertEquals(def, results.b);
+
+            assertEquals(results.finalListA, expectedAbcde);
+            assertEquals(results.finalListB, expectedDef);
+        } else {
+            assertEquals(abcde, results.b);
+            assertEquals(def, results.a);
+
+            assertEquals(results.finalListA, expectedDef);
+            assertEquals(results.finalListB, expectedAbcde);
+        }
+    }
+
+    @Test
+    public void TestSubmissionsDuplicatedToken() throws ChecksimException {
+        AlgorithmResults results = lineCompare.detectSimilarity(aabc, abc);
+
+        TokenList expectedAbc = TokenList.cloneTokenList(abc.getContentAsTokens());
+        expectedAbc.stream().forEach((token) -> token.setValid(false));
+
+        TokenList expectedAabc = TokenList.cloneTokenList(aabc.getContentAsTokens());
+        expectedAabc.stream().forEach((token) -> token.setValid(false));
+
+        assertNotNull(results);
+        assertFalse(results.identicalTokensA == results.identicalTokensB);
+
+        if(abc.equals(results.a)) {
+            assertEquals(results.b, aabc);
+
+            assertEquals(results.identicalTokensA, abc.getNumTokens());
+            assertEquals(results.identicalTokensB, aabc.getNumTokens());
+
+            assertEquals(results.finalListA, expectedAbc);
+            assertEquals(results.finalListB, expectedAabc);
+        } else {
+            assertEquals(results.a, aabc);
+            assertEquals(results.b, abc);
+
+            assertEquals(results.identicalTokensB, abc.getNumTokens());
+            assertEquals(results.identicalTokensA, aabc.getNumTokens());
+
+            assertEquals(results.finalListB, expectedAbc);
+            assertEquals(results.finalListA, expectedAabc);
+        }
+    }
+}

--- a/src/test/java/edu/wpi/checksims/token/LexemeMapTest.java
+++ b/src/test/java/edu/wpi/checksims/token/LexemeMapTest.java
@@ -1,0 +1,86 @@
+package edu.wpi.checksims.token;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for mapping lexemes to tokens
+ */
+public class LexemeMapTest {
+    @Before
+    public void setUp() {
+        LexemeMap.resetMappings();
+    }
+
+    @Test
+    public void TestCanAddAndRetrieveOneToken() {
+        int lexeme = LexemeMap.getLexemeForToken("hello");
+        Object token = LexemeMap.getTokenForLexeme(lexeme);
+
+        assertNotNull(token);
+        assertEquals(token, "hello");
+    }
+
+    @Test
+    public void TestCanRepeatedlyRetrieveOneToken() {
+        int lexeme = LexemeMap.getLexemeForToken("hello");
+        Object token = LexemeMap.getTokenForLexeme(lexeme);
+        Object token2 = LexemeMap.getTokenForLexeme(lexeme);
+        Object token3 = LexemeMap.getTokenForLexeme(lexeme);
+
+        assertNotNull(token);
+        assertNotNull(token2);
+        assertNotNull(token3);
+        assertEquals(token, "hello");
+        assertEquals(token2, token);
+        assertEquals(token3, token2);
+    }
+
+    @Test
+    public void TestAddOneTokenTwiceGivesSameLexeme() {
+        int lexeme = LexemeMap.getLexemeForToken("hello");
+        int lexeme2 = LexemeMap.getLexemeForToken("hello");
+
+        assertEquals(lexeme, lexeme2);
+    }
+
+    @Test
+    public void TestAddTwoTokensGivesDifferentLexemes() {
+        int lexeme = LexemeMap.getLexemeForToken("hello");
+        int lexeme2 = LexemeMap.getLexemeForToken("world");
+
+        assertNotEquals(lexeme, lexeme2);
+    }
+
+    @Test
+    public void TestAddAndRetrieveTwoTokens() {
+        int lexeme = LexemeMap.getLexemeForToken("hello");
+        int lexeme2 = LexemeMap.getLexemeForToken("world");
+
+        Object token1 = LexemeMap.getTokenForLexeme(lexeme);
+        Object token2 = LexemeMap.getTokenForLexeme(lexeme2);
+
+        assertNotNull(token1);
+        assertNotNull(token2);
+        assertEquals(token1, "hello");
+        assertEquals(token2, "world");
+    }
+
+    @Test
+    public void TestRetrieveAfterAdd() {
+        int lexeme = LexemeMap.getLexemeForToken("hello");
+
+        Object token1 = LexemeMap.getTokenForLexeme(lexeme);
+
+        LexemeMap.getLexemeForToken("world");
+
+        Object token2 = LexemeMap.getTokenForLexeme(lexeme);
+
+        assertNotNull(token1);
+        assertNotNull(token2);
+        assertEquals(token1, "hello");
+        assertEquals(token1, token2);
+    }
+}

--- a/src/test/java/edu/wpi/checksims/token/TokenListTest.java
+++ b/src/test/java/edu/wpi/checksims/token/TokenListTest.java
@@ -22,7 +22,9 @@
 package edu.wpi.checksims.token;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
@@ -39,6 +41,9 @@ public class TokenListTest {
     private TokenList twoElementsCharacter;
     private TokenList threeElementsCharacter;
     private TokenList twoElementsOneInvalidCharacter;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -186,6 +191,58 @@ public class TokenListTest {
         clone.get(0).setValid(!clone.get(0).isValid());
 
         assertFalse(clone.equals(oneElementCharacter));
+    }
+
+    @Test
+    public void TestImmutableCopyOnEmptyIsStillEmpty() {
+        TokenList immutableClone = TokenList.immutableCopy(emptyCharacter);
+
+        assertNotNull(immutableClone);
+        assertTrue(immutableClone.isEmpty());
+        assertEquals(immutableClone.type, emptyCharacter.type);
+    }
+
+    @Test
+    public void TestImmutableCopyDoesNotModify() {
+        TokenList immutableClone = TokenList.immutableCopy(oneElementCharacter);
+
+        assertNotNull(immutableClone);
+        assertFalse(immutableClone.isEmpty());
+        assertEquals(immutableClone.type, oneElementCharacter.type);
+        assertEquals(immutableClone.size(), oneElementCharacter.size());
+        assertEquals(immutableClone, oneElementCharacter);
+    }
+
+    @Test
+    public void TestImmutableCopyOnMultiElement() {
+        TokenList immutableClone = TokenList.immutableCopy(threeElementsCharacter);
+
+        assertNotNull(immutableClone);
+        assertFalse(immutableClone.isEmpty());
+        assertEquals(immutableClone.type, threeElementsCharacter.type);
+        assertEquals(immutableClone.size(), threeElementsCharacter.size());
+        assertEquals(immutableClone, threeElementsCharacter);
+    }
+
+    @Test
+    public void TestImmutableCopyPreservesValidity() {
+        TokenList immutableClone = TokenList.immutableCopy(twoElementsOneInvalidCharacter);
+
+        assertNotNull(immutableClone);
+        assertFalse(immutableClone.isEmpty());
+        assertEquals(immutableClone.type, twoElementsOneInvalidCharacter.type);
+        assertEquals(immutableClone.size(), twoElementsOneInvalidCharacter.size());
+        assertFalse(immutableClone.get(1).isValid());
+        assertEquals(immutableClone, twoElementsOneInvalidCharacter);
+    }
+
+    @Test
+    public void TestImmutableCopyPreventsModification() {
+        expectedEx.expect(UnsupportedOperationException.class);
+
+        TokenList immutableClone = TokenList.immutableCopy(emptyCharacter);
+
+        immutableClone.add(new ConcreteToken('E', TokenType.CHARACTER));
     }
 
     @Test

--- a/src/test/java/edu/wpi/checksims/token/TokenTest.java
+++ b/src/test/java/edu/wpi/checksims/token/TokenTest.java
@@ -25,9 +25,9 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Basic tests on Tokens

--- a/src/test/java/edu/wpi/checksims/token/tokenizer/FileLineTokenizerTest.java
+++ b/src/test/java/edu/wpi/checksims/token/tokenizer/FileLineTokenizerTest.java
@@ -37,6 +37,7 @@ public class FileLineTokenizerTest {
     private static final String oneString = "hello";
     private static final String multiLine = "hello\nworld\n";
     private static final String multiLineNoTrailing = "hello\nworld";
+    private static final String threeLine = "A\nB\nC\n";
     private static FileLineTokenizer l;
 
     @BeforeClass
@@ -90,6 +91,21 @@ public class FileLineTokenizerTest {
         assertNotNull(results);
         assertFalse(results.isEmpty());
         assertEquals(results.size(), 2);
+        assertEquals(results, expected);
+    }
+
+    @Test
+    public void TestThreeLineSplit() {
+        TokenList results = l.splitFile(threeLine);
+
+        TokenList expected = new TokenList(TokenType.LINE);
+        expected.add(new ConcreteToken("A", TokenType.LINE));
+        expected.add(new ConcreteToken("B", TokenType.LINE));
+        expected.add(new ConcreteToken("C", TokenType.LINE));
+
+        assertNotNull(results);
+        assertFalse(results.isEmpty());
+        assertEquals(results.size(), 3);
         assertEquals(results, expected);
     }
 }


### PR DESCRIPTION
Also has some misc code changes I've been working on --- more unit tests, common code removal uses better threading.

Common code removal is also still broken. Debugging that.

But the important part: comment-stripping anon script is now in the repo, and included in the report. The one we didn't write but do use is in there too, but I didn't bother actually including it in the report. We'll see if Lauer is happy with things the way they are.